### PR TITLE
Fixes import issues for testcase

### DIFF
--- a/server.R
+++ b/server.R
@@ -296,7 +296,7 @@ shinyServer(function(input, output, session) {
         # since a lot of MS data is very sparse and only using the first 1000
         # rows to guess may guess a column type wrong
         # Custom behavior for report
-        if(file$name == 'report') {
+        if(file$file == 'report.parquet') {
           .dat <- as.data.frame(read_parquet(file=file.path(folder$Path, file[['file']])))
         }
 

--- a/settings.yaml
+++ b/settings.yaml
@@ -64,8 +64,8 @@ dia-nn:
   input_files:
     report:
       name: 'report'
-      file: 'report.parquet'
-      help: 'DIA-NN report.parquet'
+      file: 'report.tsv'
+      help: 'DIA-NN report.tsv'
       default_enabled: true
       
     ms1_extracted:

--- a/ui/import_tab.R
+++ b/ui/import_tab.R
@@ -66,17 +66,17 @@ import_tab <- tabItem(tabName='import', fluidPage(
   p(class='import-help', 'Once folders are selected, click "Load Data" to import the files and begin the analysis. The status panel below to the right will update when the data is imported.'),
   fluidRow(
     column(6,
-      div(class='upload-button-container',
-        tags$button(id='confirm_folders',
-          class='btn btn-primary action-button shiny-bound-input',
-          icon('file-upload', verify_fa = FALSE), 'Load Data')
-      )
+           div(class='upload-button-container',
+               actionButton("confirm_folders", 
+                            label = span(icon('file-upload', verify_fa = FALSE), 'Load Data'),
+                            class = 'btn-primary')
+           )
     ),
     column(6,
-      wellPanel(
-        div(class='well-header', h4('Status')),
-        htmlOutput('data_status')
-      )
+           wellPanel(
+             div(class='well-header', h4('Status')),
+             htmlOutput('data_status')
+           )
     )
   ),
   


### PR DESCRIPTION
The current DO-MS release failes to run with the testcase here:
https://do-ms.slavovlab.net/docs/getting-started-preprocessing

This PR solves the issue around the testcase and restores functionality.
Please check the change from `report.parquet` to `report.tsv` by default. Maybe you can implement a n automatic switch here or a note in the documentation.